### PR TITLE
Fix method calls from getGet prefix to get

### DIFF
--- a/app/src/main/java/com/example/shanker/pomodorotimer/MainActivity.java
+++ b/app/src/main/java/com/example/shanker/pomodorotimer/MainActivity.java
@@ -110,11 +110,12 @@ public class MainActivity extends AppCompatActivity {
         mSessionType=SessionType.WORK;
         mTimerState=TimerState.RUNNING;
         SettingsFragment settingFrag = (SettingsFragment)getSupportFragmentManager().findFragmentById(R.id.settings_fragment);
+
         mTimer=new Timer();
-        mTimer.setWorkTime(TimeUnit.MINUTES.toSeconds(settingFrag.getGetWorkTime()));
-        mTimer.setShortBreak(TimeUnit.MINUTES.toSeconds(settingFrag.getGetBreakTime()));
-        mTimer.setLongBreak(TimeUnit.MINUTES.toSeconds(settingFrag.getGetLongBreakTime()));
-        mTimer.setRecurringLongBreak(settingFrag.getGetRecurringCount());
+        mTimer.setWorkTime(TimeUnit.MINUTES.toSeconds(settingFrag.getWorkTime()));
+        mTimer.setShortBreak(TimeUnit.MINUTES.toSeconds(settingFrag.getBreakTime()));
+        mTimer.setLongBreak(TimeUnit.MINUTES.toSeconds(settingFrag.getLongBreakTime()));
+        mTimer.setRecurringLongBreak(settingFrag.getRecurringCount());
         mPlaceHolderActivityName = settingFrag.getEditActivityText();
 //        if(mPlaceHolderActivityName==mEmpty)
 //            mPlaceHolderActivityName=mDefaultActivity;


### PR DESCRIPTION
Fix the 4 places where the word `get` is duplicated.

Example
```
mTimer.setWorkTime(TimeUnit.MINUTES.toSeconds(settingFrag.getGetWorkTime()));
```
https://github.com/Grimkey/DFS-Interview/blob/d2c4092c625126c511ec8f480a656163f1e2ee2b/app/src/main/java/com/example/shanker/pomodorotimer/MainActivity.java#L114

In all four cases, the actual code is just a lowercase `get`:
```
    public int getWorkTime() {
        return workTime;
    }
```